### PR TITLE
Allow for deployment without gulp on the server

### DIFF
--- a/helper/scss.js
+++ b/helper/scss.js
@@ -32,6 +32,13 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
     dest.push(config.projectPath + theme.dest + '/' + locale);
   });
 
+  // Gene Edit
+  if (config.finalTheme && production) {
+    dest.push(config.projectPath + theme.src + '/web');
+    console.log("Moving Compiled CSS to " + name + " web/css directory");
+  }
+  // end Gene Edit
+
   return gulp.src(
     file || srcBase + '/**/*.scss',
     { base: srcBase }

--- a/task/styles.js
+++ b/task/styles.js
@@ -14,6 +14,13 @@ module.exports = function() { // eslint-disable-line func-names
 
   // Loop through themes to compile scss or less depending on your config.json
   themes.forEach(name => {
+
+    // Gene Edit
+    if(name === themes[2] ){
+      config.finalTheme = true;
+    }
+    // end Gene Edit
+
     streams.add(require('../helper/scss')(gulp, plugins, config, name));
   });
 


### PR DESCRIPTION
## The Problem
Frontools moves CSS directly in to `pub/static` and this gets cleared when deploying. We have decided not to install node and gulp on the server, so running frontools on deploy is not an option.

## The Solution
This change adds a second 'dest' for the compiled CSS.

When running `gulp styles --prod`, the CSS will now be compiled to `[module]/web/css`, meaning that `setup:upgrade` or `content:deploy` will move that file in to production.

`--prod` is required to minify the CSS and remove source maps and should be run before any PR is submitted.

We will need to add this gulp task to Jenkins to double check that it has been run and fail a PR if it hasn't.

## Problems with my solution
- It's checking for the 3rd theme, and assuming it's the last, we might be better off with "finalTheme" being set in the "themes.json" config file? But it might be easier to ignore / forget if it's here.